### PR TITLE
Preprocess middleware experiments

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,9 @@ const createDecider = (exps) => {
   validate(experiences);
 
   let counter = 0;
+  // inject the name of the experience on the experience object since later it will be used 
+  // for cookie generation, etc.
+  each(experiences, (x, k) => (x.name = k));
   each(experiences, (x, k) => {
     for(let i = counter; i < counter + x.weight; i++) {
       expsDist[i] = x;


### PR DESCRIPTION
Instead of always go through all experiments for every request to pick one based on the random number. We preprocess the experiments when the middleware is created and create an array where experiments are distributed based on their weight. Then the way to pick an experiment is just getting a random number and accessing the array by index.